### PR TITLE
direnvの設定ファイルをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /data
+.envrc


### PR DESCRIPTION
- ecs-cliを使うためのAWSアクセスキーとシークレットキーを環境変数に設定
- 環境変数の管理はdirenvを使う
- direnvの設定ファイルをgitignoreに追加した